### PR TITLE
set AWS_REGION for downstream actions  which don't respect AWS_DEFAUL…

### DIFF
--- a/issue-credentials/README.md
+++ b/issue-credentials/README.md
@@ -3,8 +3,8 @@
 This GitHub Action hits the promotion service, assesses the repository and image against security standards and issues the requested ephemeral credentials if the checks are passed
 
 Right now the types issued are:
-* Kubernetes - Obtains a kubeconfig for the requested EKS environemnt and uses that context. Additionally sets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` and `AWS_SESSION_TOKEN` for use in later job steps
-* Terraform - Sets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` and `AWS_SESSION_TOKEN` for use in later job steps
+* Kubernetes - Obtains a kubeconfig for the requested EKS environemnt and uses that context. Additionally sets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `AWS_REGION`, and `AWS_SESSION_TOKEN` for use in later job steps
+* Terraform - Sets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `AWS_REGION`, and `AWS_SESSION_TOKEN` for use in later job steps
 
 # Usage
 ## General

--- a/issue-credentials/lib/issue_credentials.js
+++ b/issue-credentials/lib/issue_credentials.js
@@ -59,6 +59,7 @@ function setAwsCredentials(credentials) {
         core.exportVariable('AWS_ACCESS_KEY_ID', credentials.accessKeyId);
         core.exportVariable('AWS_SECRET_ACCESS_KEY', credentials.secretAccessKey);
         core.exportVariable('AWS_DEFAULT_REGION', core.getInput('aws_region', { required: true }));
+        core.exportVariable('AWS_REGION', core.getInput('aws_region', { required: true }));
         core.exportVariable('AWS_SESSION_TOKEN', credentials.sessionToken);
         console.log("AWS session credentials set");
     }

--- a/issue-credentials/package.json
+++ b/issue-credentials/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "main": "lib/issue_credentials.js",
     "scripts": {
-        "build": "tsc --outDir .\\lib\\ --rootDir .\\src\\"
+        "build": "tsc --outDir lib/ --rootDir src/"
     },
     "keywords": [
         "actions",

--- a/issue-credentials/src/issue_credentials.ts
+++ b/issue-credentials/src/issue_credentials.ts
@@ -62,6 +62,7 @@ function setAwsCredentials(credentials) {
         core.exportVariable('AWS_ACCESS_KEY_ID', credentials.accessKeyId);
         core.exportVariable('AWS_SECRET_ACCESS_KEY', credentials.secretAccessKey);
         core.exportVariable('AWS_DEFAULT_REGION', core.getInput('aws_region', {required: true}));
+        core.exportVariable('AWS_REGION', core.getInput('aws_region', {required: true}));
         core.exportVariable('AWS_SESSION_TOKEN', credentials.sessionToken);
         console.log("AWS session credentials set")
     }


### PR DESCRIPTION
I ran into a situation where a downstream action was using the node sdk, which expects an environment variable AWS_REGION rather than AWS_DEFAULT_REGION. It took a little while to debug this. It would be nice if issue credentials set both.