### PR TITLE
chore: check if jfrog is already installed prior to installing

### DIFF
--- a/jfrog-image-push-and-scan/action.yaml
+++ b/jfrog-image-push-and-scan/action.yaml
@@ -52,7 +52,7 @@ runs:
         cat build_data.env >> $GITHUB_ENV
       shell: bash
     - run: |
-        if ! command -v jfrog; then
+        if ! command -v jfrog > /dev/null 2>&1; then
           echo "couldn't find jfrog on my path, so i'm going to attempt to install the debian package"
           wget https://releases.jfrog.io/artifactory/jfrog-debs/pool/jfrog-cli/jfrog-cli-1.44.0.x86_64.deb
           sudo apt update

--- a/jfrog-image-push-and-scan/action.yaml
+++ b/jfrog-image-push-and-scan/action.yaml
@@ -52,11 +52,13 @@ runs:
         cat build_data.env >> $GITHUB_ENV
       shell: bash
     - run: |
-        wget https://releases.jfrog.io/artifactory/jfrog-debs/pool/jfrog-cli/jfrog-cli-1.44.0.x86_64.deb
-
-        sudo apt update
-        sudo dpkg -i ./jfrog-cli-1.44.0.x86_64.deb
-        sudo apt-get install -f
+        if ! command -v jfrog; then
+          echo "couldn't find jfrog on my path, so i'm going to attempt to install the debian package"
+          wget https://releases.jfrog.io/artifactory/jfrog-debs/pool/jfrog-cli/jfrog-cli-1.44.0.x86_64.deb
+          sudo apt update
+          sudo dpkg -i ./jfrog-cli-1.44.0.x86_64.deb
+          sudo apt-get install -f
+        fi
 
         jfrog rt c import ${{ inputs.jf-token }} --interactive=false
         jfrog rt use ${{ inputs.jf-tenant }}


### PR DESCRIPTION
should allow us to use this in dependent builds:

```
      - uses: jfrog/setup-jfrog-cli@v3
        with:
          version: 1.44.0
```

which should enable the following features (without breaking anything, hopefully):

1. tool caching
2. no assumption of the underlying os package manager (e.g. apt not available on amazon linux)